### PR TITLE
Adds language on role & enter/exit of role.

### DIFF
--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -1,5 +1,15 @@
 # Maintainers
 
+## Purpose of Maintainer Role
+
+Maintainers are representatives of The Odin Project community who assist with moderating the official Discord server and the management of processes on the Github account.
+
+### Admission and Removal of Role
+
+Maintainers, and those wishing to be considered for the Maintainer role, are expected to make regular and positive contributions to The Odin Project community. Maintainers are expected to make contributions to The Odin Project curriculum and provide support for the Discord server.
+
+Being that contributions will vary in substance and frequency, the Core team will determine if the member is meeting the expectations for the Maintainer role. If the expectations are not being met, the member will not be considered for the Maintainer role. If member is currently a Maintainer, they will be moved to Maintainer-Emeritus role with the option to return to Maintainer status upon making regular contributions.
+
 ## Github Responsibilities and Guidelines
 
 ### Maintain Issues

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -6,7 +6,7 @@ Maintainers are representatives of The Odin Project community who assist with mo
 
 ### Admission and Removal of Role
 
-Maintainers, and those wishing to be considered for the Maintainer role, are expected to make regular and positive contributions to The Odin Project community. Maintainers are expected to make contributions to The Odin Project curriculum and provide support for the Discord server.
+Maintainers, and those wishing to be considered for the Maintainer role, are expected to have a record of regular and positive contributions to The Odin Project community. Maintainers are expected to make contributions to The Odin Project curriculum and provide support for the Discord server.
 
 Being that contributions will vary in substance and frequency, the Core team will determine if the member is meeting the expectations for the Maintainer role. If the expectations are not being met, the member will not be considered for the Maintainer role. If member is currently a Maintainer, they will be moved to Maintainer-Emeritus role with the option to return to Maintainer status upon making regular contributions.
 


### PR DESCRIPTION
Adds language on what a Maintainer is and what Core team will consider when adding or removing role. Also makes clear the ability to return to Maintainer status.